### PR TITLE
Add bpm.enabled to job spec

### DIFF
--- a/jobs/bbr-acme-db/spec
+++ b/jobs/bbr-acme-db/spec
@@ -29,3 +29,6 @@ properties:
   release_level_backup:
     default: false
     description: "Use newer bbr scripts which are split by release"
+  bpm.enabled:
+    default: false
+    description: "Enable Bosh Process Manager"


### PR DESCRIPTION
The existing backup and restore templates won't compile without the `bpm.enabled` property.

(Thanks for the exemplar)